### PR TITLE
fix: correct Chrome path on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+var os = require('os'),
+    fs = require('fs');
+
 var ChromeBrowser = function(baseBrowserDecorator, args) {
   baseBrowserDecorator(this);
 
@@ -53,9 +56,10 @@ ChromeCanaryBrowser.prototype = {
 
 ChromeCanaryBrowser.$inject = ['baseBrowserDecorator', 'args'];
 
-function windowsChromePath(chromeExe) {
-	var os = require('os'),
-	    fs = require('fs');
+var windowsChromePath = function(chromeExe) {
+	if(os.platform()!=='win32')
+		return '';
+		
 	var globalInstall = os.arch()==='x64' ? process.env['ProgramFiles(x86)'] : process.env.ProgramFiles;
 	
 	if(fs.existsSync(globalInstall + chromeExe))


### PR DESCRIPTION
Checks for Chrome in the default location on windows taking into account
32 and 64 bit machines.  Falls back to the version in the user's
profile.

Closes #2
