### PR TITLE
Drop --start-maximized option

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ var ChromeBrowser = function(baseBrowserDecorator, args) {
       '--no-default-browser-check',
       '--no-first-run',
       '--disable-default-apps',
-      '--disable-popup-blocking',
-      '--start-maximized'
+      '--disable-popup-blocking'
     ].concat(flags, [url]);
   };
 };


### PR DESCRIPTION
This option was a workaround for Windows-specific issue
https://code.google.com/p/chromium/issues/detail?id=151836

It does not seem needed anymore and it creates odd experience when launching tests.

I am not using Windows as main development platform but I have tested with a minimal karma setup on Windows 7 with latest Chrome stable version (34.0.1847.131). I could not trigger that issue after having dropped the option: Chrome is normally launched (visible and not maximized).

Perhaps to be confirmed on other (Windows) systems before merging this PR.
