### PR TITLE
fix: the translation is now disabled on launch

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ var ChromeBrowser = function(baseBrowserDecorator, args) {
       '--no-default-browser-check',
       '--no-first-run',
       '--disable-default-apps',
-      '--disable-popup-blocking'
+      '--disable-popup-blocking',
+      '--disable-translate'
     ].concat(flags, [url]);
   };
 };


### PR DESCRIPTION
As the '--user-data-dir' option is provided on the browsers launch with a dumb
directory, the user options are not kept (deliberately). Therefore if the user's
browser language is not English, it will ask to translate the Karma page at each
launch, which can be annoying. To address this issue, this fix manually disables
the translation by passing the appropriate command line argument.

Related issue: https://github.com/karma-runner/karma-chrome-launcher/issues/15
