### PR TITLE
add chromium instead of google-chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ ChromeBrowser.prototype = {
   name: 'Chrome',
 
   DEFAULT_CMD: {
-    linux: 'google-chrome',
+    linux: 'chromium-browser',
     darwin: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
     win32: getChromeExe('Chrome')
   },


### PR DESCRIPTION
As the headline tells i changed the google-chrome, which does not exist on ubuntu linux to its representation: chromium. Its almost the same and works that way.

Or is there a way to switch the browser on the fly?