### PR TITLE
feature(Launcher): Add an option to disable the checked mode when launching Dartium

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,12 +79,18 @@ ChromeCanaryBrowser.$inject = ['baseBrowserDecorator', 'args'];
 var DartiumBrowser = function(baseBrowserDecorator, args) {
     ChromeBrowser.call(this, baseBrowserDecorator, args);
 
-    var checkedFlag = '--checked';
-    var dartFlags = process.env['DART_FLAGS'] || '';
-    var flags = dartFlags.split(' ')
-    if(flags.indexOf(checkedFlag) == -1) {
-        flags.push(checkedFlag);
-        process.env['DART_FLAGS'] = flags.join(' ');
+    if (args.checkedMode !== false) {
+        addCheckedModeFlag();
+    }
+
+    function addCheckedModeFlag() {
+        var checkedFlag = '--checked';
+        var dartFlags = process.env['DART_FLAGS'] || '';
+        var flags = dartFlags.split(' ');
+        if (flags.indexOf(checkedFlag) == -1) {
+          flags.push(checkedFlag);
+          process.env['DART_FLAGS'] = flags.join(' ');
+        }
     }
 };
 


### PR DESCRIPTION
The PR makes launching Dartium with the checked mode off possible.

Config example:

    customLaunchers: {
      DartiumCheckedModeOff: {
        base: 'Dartium',
        checkedMode: false
      }
    }