### PR TITLE
fix: try to use $BROWSER on linux if usingg chromium.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ ChromeBrowser.prototype = {
   name: 'Chrome',
 
   DEFAULT_CMD: {
-    linux: 'google-chrome',
+    linux: /chrome|chromium/.test(process.env.BROWSER)
+      ? process.env.BROWSER
+      : 'google-chrome', // possibly use chromium
     darwin: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
     win32: getChromeExe('Chrome')
   },


### PR DESCRIPTION
This will use chromium if the user has it specified in $BROWSER. We could also use chromium by default in linux since google-chrome is proprietary software and chromium is more linux-y.