### PR TITLE
Added readme info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,7 @@
     "Marko Vuksanovic <markovuksanovic@gmail.com>",
     "Michał Gołębiowski <m.goleb@gmail.com>",
     "Parashuram N <code@r.nparashuram.com>"
-  ]
+  ],
+  "readme": "\n# karma-chrome-launcher\n\nLauncher for Google Chrome and Google Chrome Canary\n",
+  "readmeFilename": "README.md"
 }


### PR DESCRIPTION
Added *readme* and *readmeFilename* properties to **package.json** to avoid the following warning during npm install:

```npm WARN package.json karma-chrome-launcher@0.1.4 No README data```