### PR TITLE
fix: fix #49 where karma launcher aborts if homePath is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,10 +85,12 @@ function getChromeDarwin(defaultPath) {
     return null;
   }
 
-  var homePath = path.join(process.env.HOME, defaultPath);
-  if (fs.realpathSync(homePath)) {
-    return homePath;
-  }
+  try {
+    var homePath = path.join(process.env.HOME, defaultPath);
+    if (fs.realpathSync(homePath)) {
+      return homePath;
+    }
+  } catch (e) {}
 
   return defaultPath;
 }


### PR DESCRIPTION
This PR fixes issue #49 where karma launcher fails on darwin.