### PR TITLE
Use fs.accessSync instead of fs.realpathSync and catch exceptions (fixes #49)

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,10 +54,11 @@ function getChromeExe(chromeDirName) {
 
   for (i = 0; i < prefixes.length; i++) {
     prefix = prefixes[i];
-    if (fs.realpathSync(prefix + suffix)) {
-      windowsChromeDirectory = prefix + suffix;
-      break;
-    }
+    try {
+      windowsChromeDirectory = path.join(prefix, suffix);
+      fs.accessSync(windowsChromeDirectory);
+      return windowsChromeDirectory;
+    } catch (e) {}
   }
 
   return windowsChromeDirectory;
@@ -85,12 +86,13 @@ function getChromeDarwin(defaultPath) {
     return null;
   }
 
-  var homePath = path.join(process.env.HOME, defaultPath);
-  if (fs.realpathSync(homePath)) {
+  try {
+    var homePath = path.join(process.env.HOME, defaultPath);
+    fs.accessSync(homePath);
     return homePath;
+  } catch (e) {
+    return defaultPath;
   }
-
-  return defaultPath;
 }
 
 ChromeBrowser.prototype = {


### PR DESCRIPTION
Both `fs.accessSync` and `fs.realpathSync` throw exceptions that need be
caught. There is no requirement to use `realpath`, since we don't use relative
paths.