### PR TITLE
fix(ChromeCanary): on Linux it can be named google-chrome-unstable

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ ChromeCanaryBrowser.prototype = {
   name: 'ChromeCanary',
 
   DEFAULT_CMD: {
-    linux: 'google-chrome-canary',
+    linux: getBin(['google-chrome-canary', 'google-chrome-unstable']),
     darwin: getChromeDarwin('/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'),
     win32: getChromeExe('Chrome SxS')
   },


### PR DESCRIPTION
cc @Dignifiedquire  @zzo