### PR TITLE
Allow --user-data-dir to be set in launcher properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ module.exports = function(config) {
 }
 ```
 
+The `--user-data-dir` is set to a temporary directory but can be overridden on a custom launcher as shown below.
+One reason to do this is to have a permanent Chrome user data directory inside the project directory to be able to
+install plugins there (e.g. JetBrains IDE Support plugin).
+
+```js
+customLaunchers: {
+  Chrome_with_debugging: {
+    base: 'Chrome',
+    chromeDataDir: path.resolve(__dirname, '.chrome')
+  }
+}
+```
+
 You can pass list of browsers as a CLI argument too:
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var ChromeBrowser = function (baseBrowserDecorator, args) {
   baseBrowserDecorator(this)
 
   var flags = args.flags || []
+  var userDataDir = args.chromeDataDir || this._tempDir
 
   this._getOptions = function (url) {
     // Chrome CLI options
@@ -32,7 +33,7 @@ var ChromeBrowser = function (baseBrowserDecorator, args) {
     })
 
     return [
-      '--user-data-dir=' + this._tempDir,
+      '--user-data-dir=' + userDataDir,
       '--no-default-browser-check',
       '--no-first-run',
       '--disable-default-apps',


### PR DESCRIPTION
Add a new `chromeDataDir` property to explicitly set the Chrome data
directory. Rationale:

Sometimes it is useful to run Chrome under Karma with certain plugins
loaded. One use-case is to have the **JetBrains IDE Support** plugin to
attach the IntelliJ debugger. We can do it with `--load-extension` but
this can also be prohibited by corporate policy. So one way to solve it
is to have the `--user-data-dir` point to a project subdirectory and to
install the plugin manually on the first run. It is preserved of course
on subsequent runs.