### PR TITLE
fix:disable new printer notification

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ var ChromeBrowser = function (baseBrowserDecorator, args) {
       '--disable-default-apps',
       '--disable-popup-blocking',
       '--disable-translate',
-      '--disable-background-timer-throttling'
+      '--disable-background-timer-throttling',
+      '--disable-device-discovery-notifications'
     ].concat(flags, [url])
   }
 }


### PR DESCRIPTION
Pass the '--disable-device-discovery-notifications' to avoid message "New
printer on your network" which can be very annoying when running tests