### PR TITLE
chore(linter): switch from eslint to standard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "standard"
-}

--- a/examples/simple/index.spec.js
+++ b/examples/simple/index.spec.js
@@ -1,5 +1,7 @@
+/* eslint-env mocha */
+
 describe('ChromeLauncher', function () {
   it('works', function () {
-    1 + 1 === 2
+    return 1 + 1 === 2
   })
 })

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -59,21 +59,13 @@ module.exports = function (grunt) {
       simple: {
         configFile: 'examples/simple/karma.conf.js'
       }
-    },
-    eslint: {
-      target: [
-        'index.js',
-        'gruntfile.js',
-        'test/*.js',
-        'examples/**/*.js'
-      ]
     }
   })
 
   require('load-grunt-tasks')(grunt)
 
   grunt.registerTask('test', ['simplemocha'])
-  grunt.registerTask('default', ['eslint', 'test'])
+  grunt.registerTask('default', ['test'])
 
   grunt.registerTask('release', 'Bump the version and publish to NPM.', function (type) {
     grunt.task.run([

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "A Karma plugin. Launcher for Chrome and Chrome Canary.",
   "main": "index.js",
   "scripts": {
+    "lint": "standard",
+    "pretest": "npm run lint",
     "test": "grunt test"
   },
   "repository": {
@@ -23,15 +25,11 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.3.0",
-    "eslint": "^1.6.0",
-    "eslint-config-standard": "^4.4.0",
-    "eslint-plugin-standard": "^1.3.1",
     "grunt": "^0.4.1",
     "grunt-auto-release": "^0.0.6",
     "grunt-bump": "^0.6.0",
     "grunt-conventional-changelog": "^5.0.0",
     "grunt-conventional-github-releaser": "^0.5.0",
-    "grunt-eslint": "^17.2.0",
     "grunt-karma": "1.x || ^0.12.1",
     "grunt-npm": "^0.0.2",
     "grunt-simple-mocha": "^0.4.0",
@@ -40,7 +38,8 @@
     "karma-mocha": "1.x || ^0.2.0",
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^2.3.3",
-    "sinon": "^1.17.1"
+    "sinon": "^1.17.1",
+    "standard": "^7.1.2"
   },
   "contributors": [
     "Mark Ethan Trostler <mark@zzo.com>",

--- a/test/jsflags.spec.js
+++ b/test/jsflags.spec.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+
 var expect = require('chai').expect
 var sinon = require('sinon')
 


### PR DESCRIPTION
We are currently using eslint with standard plugin for linting the
project's code. This is practically the same as using standard alone,
and has the advantage of not needing all the eslint packages, resulting
in a lot less setup and noise from greenkeeper.

**Note:** standard version was downgraded to `v7.1.2` to maintain compatibility with supported node engines.