### PR TITLE
Add support for headless Chrome/ChromeCanary

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,5 +297,6 @@ module.exports = {
 module.exports.test = {
   isJSFlags: isJSFlags,
   sanitizeJSFlags: sanitizeJSFlags,
+  headlessGetOptions: headlessGetOptions,
   canaryGetOptions: canaryGetOptions
 }

--- a/test/jsflags.spec.js
+++ b/test/jsflags.spec.js
@@ -53,3 +53,20 @@ describe('canaryGetOptions', function () {
     ])
   })
 })
+
+describe('headlessGetOptions', function () {
+  var headlessGetOptions = launcher.test.headlessGetOptions
+
+  it('should return the headless flags', function () {
+    var parent = sinon.stub().returns(['-incognito'])
+    var context = {}
+    var url = 'http://localhost:9876'
+    var args = {}
+    expect(headlessGetOptions.call(context, url, args, parent)).to.be.eql([
+      '-incognito',
+      '--headless',
+      '--disable-gpu',
+      '--remote-debugging-port=9222'
+    ])
+  })
+})


### PR DESCRIPTION
Tested on Linux with `google-chrome-unstable`, but as of today it should be support in macOS Chrome Canary as well.

Not really expecting this to be merged until headless support hits a stable release across multiple OSes, but figured I'd open a PR for anyone trying to figure out how to get it working. I was thinking of publishing it to npm as `karma-headless-chrome-launcher`, but it seems that name is already in use.