### PR TITLE
Switch from 'Chrome' to 'Chromium' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can pass list of browsers as a CLI argument too:
 $ karma start --browsers Chrome,Chrome_without_security
 ```
 
-## Headless Chrome with Puppeteer
+## Headless Chromium with Puppeteer
 
 Chrome team made [Puppeteer](https://github.com/GoogleChrome/puppeteer). It will automatically install Chromium for all
 platforms, so you can easily use it within your CI. Everything that you need, it's to install package and update your
@@ -71,11 +71,11 @@ const ChromiumRevision = require('puppeteer/package.json').puppeteer.chromium_re
 const Downloader = require('puppeteer/utils/ChromiumDownloader')
 const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision)
 
-process.env.CHROME_BIN = revisionInfo.executablePath
+process.env.CHROMIUM_BIN = revisionInfo.executablePath
 
 module.exports = function(config) {
   config.set({
-    browsers: ['ChromeHeadless']
+    browsers: ['ChromiumHeadless']
   })
 }
 ```


### PR DESCRIPTION
Puppeteer installs Chromium on all platforms (not Chrome).
Overload only Chromium path and reference ChromiumHeadless