### PR TITLE
chore: update travis to use latest node majors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.0"
-  - "6.0"
+  - 4
+  - 6
   - stable
 
 # Make sure we have new NPM.


### PR DESCRIPTION
This PR fixes the travis "Buffer.alloc is not a function" error on node version 4.

This happens because the new buffer api is only available starting at v4.5, and dependencies are using it.

The travis config file is using hardcoded major versions, like "4.0",
this causes travis to only test against the 4.0.0 version.