### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ process.env.CHROMIUM_BIN = revisionInfo.executablePath
 
 module.exports = function(config) {
   config.set({
-    browsers: ['ChromiumHeadless']
+    browsers: ['ChromeHeadless']
   })
 }
 ```


### PR DESCRIPTION
Otherwise it fails with:

```
12 09 2017 16:26:35.637:INFO [launcher]: Launching browser ChromiumHeadless with unlimited concurrency
12 09 2017 16:26:35.637:ERROR [launcher]: Cannot load browser "ChromiumHeadless": it is not registered! Perhaps you are missing some plugin?
12 09 2017 16:26:35.638:ERROR [karma]: Found 1 load error
npm ERR! Test failed.  See above for more details.
```