### PR TITLE
Add --no-user-gesture-required to headless chrome options

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,12 @@ ChromeBrowser.prototype = {
 ChromeBrowser.$inject = ['baseBrowserDecorator', 'args']
 
 function headlessGetOptions (url, args, parent) {
-  return parent.call(this, url, args).concat(['--headless', '--disable-gpu', '--remote-debugging-port=9222'])
+  return parent.call(this, url, args).concat([
+    '--headless',
+    '--disable-gpu',
+    '--remote-debugging-port=9222',
+    '--no-user-gesture-required'
+  ])
 }
 
 var ChromeHeadlessBrowser = function (baseBrowserDecorator, args) {

--- a/test/jsflags.spec.js
+++ b/test/jsflags.spec.js
@@ -66,7 +66,8 @@ describe('headlessGetOptions', function () {
       '-incognito',
       '--headless',
       '--disable-gpu',
-      '--remote-debugging-port=9222'
+      '--remote-debugging-port=9222',
+      '--no-user-gesture-required'
     ])
   })
 })


### PR DESCRIPTION
I think it makes sense to disable autoplay restrictions when running chrome in headless mode.