### PR TITLE
Disable proxy discovery in headless mode.

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ ChromeBrowser.prototype = {
 ChromeBrowser.$inject = ['baseBrowserDecorator', 'args']
 
 function headlessGetOptions (url, args, parent) {
-  return parent.call(this, url, args).concat(['--headless', '--disable-gpu', '--remote-debugging-port=9222'])
+  return parent.call(this, url, args).concat(['--headless', '--disable-gpu', '--remote-debugging-port=9222', '--proxy-server="direct://"', '--proxy-bypass-list=*'])
 }
 
 var ChromeHeadlessBrowser = function (baseBrowserDecorator, args) {

--- a/test/jsflags.spec.js
+++ b/test/jsflags.spec.js
@@ -66,7 +66,9 @@ describe('headlessGetOptions', function () {
       '-incognito',
       '--headless',
       '--disable-gpu',
-      '--remote-debugging-port=9222'
+      '--remote-debugging-port=9222',
+      '--proxy-server="direct://"',
+      '--proxy-bypass-list=*'
     ])
   })
 })


### PR DESCRIPTION
Corrects an issue where HeadlessChrome downloads scripts at a very slow rate. As demonstrated in the screenshot, when running headless, each script took several seconds to load, causing minutes of delay for a test run. This may not occur in all environments. Shown is Chromium 70.0.3508.0 on Windows 7 SP1.

**Note:** This does not occur if the `--headless` flag is removed, so this may be indicative of a bug in Chromium.

![image](https://user-images.githubusercontent.com/2042102/45235414-a7ca8380-b28d-11e8-8648-a14c23bb614e.png)
