### PR TITLE
fix: allow overriding of default debug port

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,15 @@ ChromeBrowser.prototype = {
 ChromeBrowser.$inject = ['baseBrowserDecorator', 'args']
 
 function headlessGetOptions (url, args, parent) {
-  return parent.call(this, url, args).concat(['--headless', '--disable-gpu', '--remote-debugging-port=9222'])
+  var mergedArgs = parent.call(this, url, args).concat(['--headless', '--disable-gpu'])
+
+  var isRemoteDebuggingFlag = function (flag) {
+    return flag.indexOf('--remote-debugging-port=') !== -1
+  }
+
+  return mergedArgs.some(isRemoteDebuggingFlag)
+    ? mergedArgs
+    : mergedArgs.concat(['--remote-debugging-port=9222'])
 }
 
 var ChromeHeadlessBrowser = function (baseBrowserDecorator, args) {

--- a/test/jsflags.spec.js
+++ b/test/jsflags.spec.js
@@ -69,4 +69,19 @@ describe('headlessGetOptions', function () {
       '--remote-debugging-port=9222'
     ])
   })
+
+  it('should not overwrite custom remote-debugging-port', function () {
+    var parent = sinon.stub().returns(
+      ['-incognito', '--remote-debugging-port=9333']
+    )
+    var context = {}
+    var url = 'http://localhost:9876'
+    var args = {}
+    expect(headlessGetOptions.call(context, url, args, parent)).to.be.eql([
+      '-incognito',
+      '--remote-debugging-port=9333',
+      '--headless',
+      '--disable-gpu'
+    ])
+  })
 })


### PR DESCRIPTION
This allows the --remote-debugging-port flag to be overridden with a custom port when using chrome headless.

Fixes #187