### PR TITLE
chore: remove node 4 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - 4
   - 6
-  - stable
+  - 8
+  - 10
 
 # Make sure we have new NPM.
 before_install:


### PR DESCRIPTION
This is needed for the builds to pass again. It should be merged before #191