### PR TITLE
added "--disable-site-isolation-trials" to Chrome_without_security

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ module.exports = function(config) {
     customLaunchers: {
       Chrome_without_security: {
         base: 'Chrome',
-        flags: ['--disable-web-security']
+        flags: ['--disable-web-security', '--disable-site-isolation-trials']
       }
     }
   })


### PR DESCRIPTION
This SO page https://stackoverflow.com/questions/53080472/chrome-disable-web-security-no-longer-works got me to what has been described here https://www.chromium.org/Home/chromium-security/site-isolation#TOC-Known-Issues so I thought it will be useful for others if the docs mention that fact :)

macOS 10.14, Chrome 75.0.3770.100
I had a problem testing a site and kept getting "Error: Uncaught SecurityError: Blocked a frame with origin..." even if I had provided "--disable-web-security" as per the example in the documentation. Seems Chrome has changed its security policies and that flag is no longer enough to get it out of the the CORS cage.