### PR TITLE
feat: add --disable-dev-shm-usage flag to headless

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,11 @@ ChromeBrowser.prototype = {
 ChromeBrowser.$inject = ['baseBrowserDecorator', 'args']
 
 function headlessGetOptions (url, args, parent) {
-  var mergedArgs = parent.call(this, url, args).concat(['--headless', '--disable-gpu'])
+  var mergedArgs = parent.call(this, url, args).concat([
+    '--headless',
+    '--disable-gpu',
+    '--disable-dev-shm-usage'
+  ])
 
   var isRemoteDebuggingFlag = function (flag) {
     return flag.indexOf('--remote-debugging-port=') !== -1

--- a/test/jsflags.spec.js
+++ b/test/jsflags.spec.js
@@ -66,6 +66,7 @@ describe('headlessGetOptions', function () {
       '-incognito',
       '--headless',
       '--disable-gpu',
+      '--disable-dev-shm-usage',
       '--remote-debugging-port=9222'
     ])
   })
@@ -81,7 +82,8 @@ describe('headlessGetOptions', function () {
       '-incognito',
       '--remote-debugging-port=9333',
       '--headless',
-      '--disable-gpu'
+      '--disable-gpu',
+      '--disable-dev-shm-usage'
     ])
   })
 })


### PR DESCRIPTION
This flag to the default options solves some issues when running chrome headless inside docker. For more details check this puppeteer issue where they discuss adding the flag to the default options as well:

https://github.com/GoogleChrome/puppeteer/issues/1834