### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,8 +332,8 @@ module.exports = {
 }
 
 module.exports.test = {
-  isJSFlags: isJSFlags,
-  sanitizeJSFlags: sanitizeJSFlags,
-  headlessGetOptions: headlessGetOptions,
-  canaryGetOptions: canaryGetOptions
+  isJSFlags,
+  sanitizeJSFlags,
+  headlessGetOptions,
+  canaryGetOptions
 }


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is supported in Node.js 4.x and up, and it seems like support for Node.js 4 was dropped in ae615d0ffcc0e7a9e80aa5a9f80bb81da3853404/3.0.0 ✅ 