### PR TITLE
feat: add process.env.ProgramW6432 as root location for binaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function getChromeExe (chromeDirName) {
   }
   var windowsChromeDirectory, i, prefix
   var suffix = '\\Google\\' + chromeDirName + '\\Application\\chrome.exe'
-  var prefixes = [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']]
+  var prefixes = [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)'], process.env.ProgramW6432]
 
   for (i = 0; i < prefixes.length; i++) {
     prefix = prefixes[i]
@@ -108,7 +108,7 @@ function getChromiumExe (chromeDirName) {
   }
   var windowsChromiumDirectory, i, prefix
   var suffix = '\\Chromium\\Application\\chrome.exe'
-  var prefixes = [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)']]
+  var prefixes = [process.env.LOCALAPPDATA, process.env.PROGRAMFILES, process.env['PROGRAMFILES(X86)'], process.env.ProgramW6432]
 
   for (i = 0; i < prefixes.length; i++) {
     prefix = prefixes[i]


### PR DESCRIPTION
On Windows systems, depending on the installed software (32 bit or 64 bit), querying process.env.PROGRAMFILES might yield 'C:\Program Files (x86)' even on a 64 bit system. That is why process.env.ProgramW6432 needs to be added as a root location, which holds 'C:\Program Files'.