### PR TITLE
Allow passing --headless=new

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,6 @@ ChromeBrowser.$inject = ['baseBrowserDecorator', 'args']
 
 function headlessGetOptions (url, args, parent) {
   var mergedArgs = parent.call(this, url, args).concat([
-    '--headless',
     '--disable-gpu',
     '--disable-dev-shm-usage'
   ])
@@ -177,9 +176,17 @@ function headlessGetOptions (url, args, parent) {
     return flag.indexOf('--remote-debugging-port=') !== -1
   }
 
-  return mergedArgs.some(isRemoteDebuggingFlag)
+  mergedArgs = mergedArgs.some(isRemoteDebuggingFlag)
     ? mergedArgs
     : mergedArgs.concat(['--remote-debugging-port=9222'])
+
+  var isHeadlessFlag = function (flag) {
+    return flag.indexOf('--headless=') !== -1
+  }
+
+  return mergedArgs.some(isHeadlessFlag)
+    ? mergedArgs
+    : mergedArgs.concat(['--headless'])
 }
 
 var ChromeHeadlessBrowser = function (baseBrowserDecorator, args) {

--- a/test/jsflags.spec.js
+++ b/test/jsflags.spec.js
@@ -64,10 +64,10 @@ describe('headlessGetOptions', function () {
     var args = {}
     expect(headlessGetOptions.call(context, url, args, parent)).to.be.eql([
       '-incognito',
-      '--headless',
       '--disable-gpu',
       '--disable-dev-shm-usage',
-      '--remote-debugging-port=9222'
+      '--remote-debugging-port=9222',
+      '--headless'
     ])
   })
 
@@ -81,9 +81,25 @@ describe('headlessGetOptions', function () {
     expect(headlessGetOptions.call(context, url, args, parent)).to.be.eql([
       '-incognito',
       '--remote-debugging-port=9333',
-      '--headless',
       '--disable-gpu',
-      '--disable-dev-shm-usage'
+      '--disable-dev-shm-usage',
+      '--headless'
+    ])
+  })
+
+  it('should not overwrite custom headless flag', function () {
+    var parent = sinon.stub().returns(
+      ['-incognito', '--headless=new']
+    )
+    var context = {}
+    var url = 'http://localhost:9876'
+    var args = {}
+    expect(headlessGetOptions.call(context, url, args, parent)).to.be.eql([
+      '-incognito',
+      '--headless=new',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+      '--remote-debugging-port=9222'
     ])
   })
 })


### PR DESCRIPTION
Fixes #270 by allowing users to pass a `--headless=new` parameter.