### PR TITLE
Several updates/fixes to the options passed to browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,37 @@ function sanitizeJSFlags (flag) {
   return flag.replace(startExp, '--js-flags=').replace(endExp, '')
 }
 
+function getOptions (userDataDir, flags, url) {
+  // These are all the default options
+  return [
+    '--user-data-dir=' + userDataDir,
+
+    // Disable chrome features
+    // https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#--enable-automation
+    '--enable-automation',
+    '--no-default-browser-check',
+    '--no-first-run',
+    '--disable-client-side-phishing-detection',
+    '--disable-default-apps',
+    '--disable-popup-blocking',
+    '--disable-features=Translate',
+    '--disable-background-timer-throttling',
+    '--disable-notifications',
+    '--mute-audio',
+
+    // Disable password prompt dialogs
+    // see: https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md#chromium-annoyances
+    '--password-store=basic',
+    '--use-mock-keychain',
+
+    // on macOS, disable-background-timer-throttling is not enough
+    // and we need disable-renderer-backgrounding too
+    // see https://github.com/karma-runner/karma-chrome-launcher/issues/123
+    '--disable-renderer-backgrounding',
+    '--disable-device-discovery-notifications'
+  ].concat(flags, [url])
+}
+
 var ChromeBrowser = function (baseBrowserDecorator, args) {
   baseBrowserDecorator(this)
 
@@ -32,22 +63,7 @@ var ChromeBrowser = function (baseBrowserDecorator, args) {
       }
     })
 
-    return [
-      '--user-data-dir=' + userDataDir,
-      // https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#--enable-automation
-      '--enable-automation',
-      '--no-default-browser-check',
-      '--no-first-run',
-      '--disable-default-apps',
-      '--disable-popup-blocking',
-      '--disable-translate',
-      '--disable-background-timer-throttling',
-      // on macOS, disable-background-timer-throttling is not enough
-      // and we need disable-renderer-backgrounding too
-      // see https://github.com/karma-runner/karma-chrome-launcher/issues/123
-      '--disable-renderer-backgrounding',
-      '--disable-device-discovery-notifications'
-    ].concat(flags, [url])
+    return getOptions(userDataDir, flags, url)
   }
 }
 
@@ -88,15 +104,7 @@ var ChromiumBrowser = function (baseBrowserDecorator, args) {
       }
     })
 
-    return [
-      '--user-data-dir=' + userDataDir,
-      '--no-default-browser-check',
-      '--no-first-run',
-      '--disable-default-apps',
-      '--disable-popup-blocking',
-      '--disable-translate',
-      '--disable-background-timer-throttling'
-    ].concat(flags, [url])
+    return getOptions(userDataDir, flags, url)
   }
 }
 


### PR DESCRIPTION
This PR adds the following changes:

- Extract common options from `ChromeBrowser` and `ChromiumBrowser`.
  - Introduce function `getOptions` instead of duplicating code.
  - Introduce options to chromium for parity.
     Previously, chrome had these options added to it to fix a bug, however they were not added to chromium.
    - Add `--disable-renderer-backgrounding` to chromium
    - Add `--disable-device-discovery-notifications` to chromium
- Introduce new options.
  - Introduce options to prevent password dialogues when running tests.
    - Add `--password-store=basic`. Prevents gnome keyring/kde wallet popup on Linux.
    - Add `--use-mock-keychain`. Prevents permissions dialog on Mac.
  - Introduce options to disable interactivity.
    - Add `--disable-popup-blocking`. Disables the "block popups" dialog.
    - Add `--disable-notifications`. Disable notifications.
    - Add `--mute-audio`. Mute audio.
    - Add `--disable-client-side-phishing-detection`. Disables client-side phishing detection.
  - Replace removed flags
    - Replace `--disable-translate` with `--disable-features=Translate`

I personally was running into an issue with the lack of `--password-store=basic` causing chromium to repeatedly prompt for a password when running tests. Originally, this PR was going to only introduce that flag, however while modifying the code to add this, I noticed a few other minor changes I could do, which is why this PR contains a few changes.

If any of the new flags introduced are blocking a merge, then I can remove them, as I'd like to get `--password-store=basic` merged.